### PR TITLE
Add appId to configuration to support deeplinks after payment flow

### DIFF
--- a/rampinstantsdk/src/main/java/network/ramp/instantsdk/facade/Config.kt
+++ b/rampinstantsdk/src/main/java/network/ramp/instantsdk/facade/Config.kt
@@ -28,6 +28,11 @@ internal data class Config(
      */
     val hostAppName: String,
     /**
+     * In mobile context we need this id to properly redirect user back to application after bank connection and payment
+     * This Id should be specified as `domain` in intent filters during SDK integration
+     */
+    val appId: String,
+    /**
      * allows to provide an alternative URL to load
      * a non-production version of the widget
      */

--- a/rampinstantsdk/src/main/java/network/ramp/instantsdk/facade/RampInstantSDK.kt
+++ b/rampinstantsdk/src/main/java/network/ramp/instantsdk/facade/RampInstantSDK.kt
@@ -16,6 +16,7 @@ class RampInstantSDK(
     private val userAddress: String,
     private val hostLogoUrl: String,
     private val hostAppName: String,
+    private val appId: String,
     private val swapAsset: String = "",
     private val swapAmount: String = "",
     private val webhookStatusUrl: String = "",
@@ -39,6 +40,7 @@ class RampInstantSDK(
                 userAddress = userAddress,
                 hostAppName = hostAppName,
                 hostLogoUrl = hostLogoUrl,
+                appId = appId,
                 url = url,
                 webhookStatusUrl = webhookStatusUrl
             )

--- a/rampinstantsdk/src/main/java/network/ramp/instantsdk/ui/rampinstant/RampInstantActivity.kt
+++ b/rampinstantsdk/src/main/java/network/ramp/instantsdk/ui/rampinstant/RampInstantActivity.kt
@@ -97,7 +97,8 @@ internal class RampInstantActivity : AppCompatActivity() {
                 concatenateIfNotBlank("&swapAmount=", config.swapAmount) +
                 concatenateIfNotBlank("&webhookStatusUrl=", config.webhookStatusUrl) +
                 "&variant=mobile&" +
-                "&hostUrl=*"
+                "&hostUrl=*" +
+                "&appId=${config.appId}"
     }
 
     private fun concatenateIfNotBlank(str1: String, str2: String): String {

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -32,7 +32,7 @@
                 <category android:name="android.intent.category.BROWSABLE" />
 
                 <data
-                    android:host="ramp"
+                    android:host="ramp-demo-app"
                     android:scheme="rampnetwork" />
             </intent-filter>
 

--- a/sample/src/main/java/network/ramp/instantsdk/demo/DemoActivity.kt
+++ b/sample/src/main/java/network/ramp/instantsdk/demo/DemoActivity.kt
@@ -25,6 +25,7 @@ class DemoActivity : AppCompatActivity() {
                 userAddress = userAddressEditText.getContent(),
                 hostLogoUrl = hostLogoUrlEditText.getContent(),
                 hostAppName = hostAppNameEditText.getContent(),
+                appId = "ramp-demo-app",
                 webhookStatusUrl = webHookStatusUrlEditText.getContent(),
                 url = urlEditText.getContent()
             )


### PR DESCRIPTION
This change enables deep links to work after payment. It requires latest widget version.